### PR TITLE
Add stream lifetime handling + robustness tests

### DIFF
--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -95,7 +95,7 @@ namespace HttpOverStream.Client
                     throw new HttpRequestException("Error parsing header", ex);
                 }
             }
-            responseContent.SetContent(new BodyStream(stream, response.Content.Headers.ContentLength), response.Content.Headers.ContentLength);
+            responseContent.SetContent(new BodyStream(stream, response.Content.Headers.ContentLength, closeOnReachEnd:true), response.Content.Headers.ContentLength);
             return response;
         }
 

--- a/src/HttpOverStream.Tests/BodyStreamTests.cs
+++ b/src/HttpOverStream.Tests/BodyStreamTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HttpOverStream.Tests
+{
+    public class BodyStreamTests
+    {
+        class TestStream : MemoryStream
+        {
+            public bool Disposed { get; private set; }
+            public TestStream(byte[] data) : base(data) { }
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                Disposed = true;
+            }
+
+        }
+        [Fact]
+        public async Task TestBodyStreamCloseOnReadEnd()
+        {
+            byte[] payload = new byte[10];
+            var ms = new TestStream(payload);
+            var bodyStream = new BodyStream(ms, 10, closeOnReachEnd: true);
+            var result = new byte[10];
+            var read = await bodyStream.ReadAsync(result, 0, 10);
+            Assert.Equal(10, read);
+            Assert.True(ms.Disposed);
+        }
+    }
+}


### PR DESCRIPTION
- Streams were not closed properly (in Owin server case + client)
- Ensured we can plug a custom Owin Logger factory to interface the host application logging system with the Owind host.
- Ensured abrubt stream closing on the client side does not crash the server.