### PR TITLE
DESKTOP-752 Add dummy thread, 5x server threads, and run background t…

### DIFF
--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -62,6 +62,7 @@ namespace HttpOverStream.Client
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ValidateAndNormalizeRequest(request);
+
             var stream = await _dial.DialAsync(request, cancellationToken).ConfigureAwait(false);
 
             request.Properties.Add(UnderlyingStreamProperty, stream);
@@ -152,7 +153,5 @@ namespace HttpOverStream.Client
                 request.Headers.ExpectContinue = false;
             }
         }
-
-
     }
 }

--- a/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Threading;
@@ -14,11 +16,13 @@ namespace HttpOverStream.NamedPipe
         private readonly PipeOptions _pipeOptions;
         private readonly PipeTransmissionMode _pipeTransmissionMode;
         private readonly int _maxAllowedServerInstances;
+        private static readonly int _numServerThreads = 5;
 
         public NamedPipeListener(string pipeName)
             : this(pipeName, PipeOptions.Asynchronous, PipeTransmissionMode.Byte, NamedPipeServerStream.MaxAllowedServerInstances)
         {
         }
+
         public NamedPipeListener(string pipeName, PipeOptions pipeOptions, PipeTransmissionMode pipeTransmissionMode, int maxAllowedServerInstances)
         {
             _pipeName = pipeName;
@@ -31,18 +35,32 @@ namespace HttpOverStream.NamedPipe
         {
             _listenTcs = new CancellationTokenSource();
             var ct = _listenTcs.Token;
-            _listenTask = Task.Run(async () =>
-            {
-                while (!ct.IsCancellationRequested)
-                {
-                    var srv = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, _maxAllowedServerInstances, _pipeTransmissionMode, _pipeOptions);
-                    await srv.WaitForConnectionAsync(ct);
-                    onConnection(srv);
-                }
-            });
+            _listenTask = StartServerAndDummyThreads(onConnection, ct);
             return Task.CompletedTask;
         }
 
+        private Task StartServerAndDummyThreads(Action<Stream> onConnection, CancellationToken cancellationToken)
+        {
+            var tasks = new List<Task>();
+
+            // We block on creating the dummy server/client to ensure we definitely have that set up before doing anything else
+            var dummyClient = ConnectDummyClientAndServer(cancellationToken);
+            tasks.Add(Task.Run(() => WaitForCancellationThenDispose(dummyClient, cancellationToken)));
+
+            // This runs synchronously until we've created the first server listener to ensure we can handle at least the first client connection
+            var listenTask = CreateServerStreamAndListen(onConnection, cancellationToken);
+            tasks.Add(listenTask);
+
+            // We don't technically need more than 1 thread but its faster
+            for (int i = 0; i < _numServerThreads-1; i++)
+            {
+                tasks.Add(Task.Run(() => CreateServerStreamAndListen(onConnection, cancellationToken)));
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        // We dont use the cancellation token but others might
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             _listenTcs.Cancel();
@@ -50,7 +68,94 @@ namespace HttpOverStream.NamedPipe
             {
                 await _listenTask.ConfigureAwait(false);
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async Task CreateServerStreamAndListen(Action<Stream> onConnection, CancellationToken cancelToken)
+        {
+            try
+            {
+                while (!cancelToken.IsCancellationRequested)
+                {
+                    var serverStream = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, _maxAllowedServerInstances, _pipeTransmissionMode, _pipeOptions);
+                    try
+                    {
+                        await serverStream.WaitForConnectionAsync(cancelToken).ConfigureAwait(false);
+
+                        // MP: We deliberately don't await this because we want to kick off the work on a background thead
+                        // and immediately check for the next client connecting
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                        Task.Run(() => onConnection(serverStream));
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+                    }
+                    catch (OperationCanceledException) // Thrown when cancellationToken is cancelled
+                    {
+                        serverStream.Dispose();
+                    }
+                    catch (IOException ex) // Thrown if client disconnects early
+                    {
+                        if (ex.Message.Contains("The pipe is being closed."))
+                        {
+                            // TODO: Replace with logger
+                            Debug.WriteLine($"Could not read Named Pipe message - client disconnected before server finished reading.");
+                        }
+                        serverStream.Dispose();
+                    }
+                    catch (Exception)
+                    {
+                        // TODO: Maybe log
+                        serverStream.Dispose();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // TODO: Replace with logger
+                Debug.WriteLine("--- Exception creating server stream or waiting for connection: " + e);
+            }
+        }
+
+        private NamedPipeClientStream ConnectDummyClientAndServer(CancellationToken cancellationToken)
+        {
+            // Always have another stream active so if HandleStream finishes really quickly theres
+            // no chance of the named pipe being removed altogether.
+            // This is the same pattern as microsofts go library -> https://github.com/Microsoft/go-winio/pull/80/commits/ecd994be061f4ae21f463bbf08166d8edc96cadb
+            var serverStream = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, _maxAllowedServerInstances, _pipeTransmissionMode, _pipeOptions);
+            serverStream.WaitForConnectionAsync(cancellationToken);
+            var dummyClientStream = new NamedPipeClientStream(".", _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            dummyClientStream.Connect(100); // 100ms timeout to connect to itself
+
+            // We only need to return the client - Server will cancel + dispose itself via the token
+            return dummyClientStream;
+        }
+
+        private async Task WaitForCancellationThenDispose(IDisposable disposable, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WhenCanceled().ConfigureAwait(false);
+
+            try
+            {
+                disposable.Dispose();
+            }
+            catch (Exception e)
+            {
+                // TODO: Replace with logger
+                Debug.WriteLine("--- Dummyclientstream dispose EXCEPTION " + e);
+            }
+        }
+    }
+
+    internal static class CancellationTokenExtensions
+    {
+        // Taken from https://github.com/dotnet/corefx/issues/2704#issuecomment-131221355
+        public static Task WhenCanceled(this CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).SetResult(true), tcs);
+            return tcs.Task;
         }
     }
 }

--- a/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
@@ -71,7 +71,7 @@ namespace HttpOverStream.NamedPipe
             }
             catch (AggregateException a) when (a.InnerExceptions.All(e => e is ObjectDisposedException))
             {
-                // NamedPipe cancellations can throw ObjectNotDisposedException
+                // NamedPipe cancellations can throw ObjectDisposedException
                 // They will be grouped in an AggregateException and this shouldnt break
             }
             try

--- a/src/HttpOverStream/HttpHeaderWriter.cs
+++ b/src/HttpOverStream/HttpHeaderWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -11,32 +12,41 @@ namespace HttpOverStream
     public static class HttpHeaderWriter
     {
         static byte[] _eol = Encoding.ASCII.GetBytes("\n");
-        public static async ValueTask WriteResponseStatusAndHeadersAsync(this Stream stream, string protocol, string statusCode, string reasonPhrase, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
+        public static async Task WriteResponseStatusAndHeadersAsync(this Stream stream, string protocol, string statusCode, string reasonPhrase, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
         {
             var statusLine = $"{protocol} {statusCode} {reasonPhrase}\n";
             var payload = Encoding.ASCII.GetBytes(statusLine);
+            Debug.WriteLine("-- Server: Trying to write statusline: " + statusLine);
             await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
+            Debug.WriteLine("-- Server: Finished writeAsync");
             await WriteHeadersAsync(stream, headers, cancellationToken).ConfigureAwait(false);
+            Debug.WriteLine("-- Server: Finished WriteHeadersAsync");
             await stream.WriteAsync(_eol, 0, _eol.Length, cancellationToken).ConfigureAwait(false);
+            Debug.WriteLine("-- Server: Finished writeAsync eol");
         }
 
-        private static async ValueTask WriteHeadersAsync(Stream stream, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
+        private static async Task WriteHeadersAsync(Stream stream, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
         {
             foreach(var header in headers)
             {
                 var separator = header.Key == "Server" ? " " : ", ";
                 var values = string.Join(separator, header.Value);
                 var line = $"{header.Key}: {values}\n";
+                //var line = $"{header.Key}: {values}\n".Substring(0, 5) + "\n"; // TODO: REMOVE SUBSTRING
                 var payload = Encoding.ASCII.GetBytes(line);
+                //await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
                 await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public static async ValueTask WriteMethodAndHeadersAsync(this Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
+        public static async Task WriteMethodAndHeadersAsync(this Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var firstLine = $"{request.Method.Method} {request.RequestUri.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped)} HTTP/{request.Version}\n";
             var payload = Encoding.ASCII.GetBytes(firstLine);
+
+            Debug.WriteLine("-- Client: Writing request - first line");
             await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
+            Debug.WriteLine("-- Client: Writing request - headers");
             await WriteHeadersAsync(stream, request.Headers, cancellationToken).ConfigureAwait(false);
             if(request.Content != null)
             {
@@ -47,7 +57,6 @@ namespace HttpOverStream
                     request.Content.Headers.ContentLength = request.Content.Headers.ContentLength;
                 }
                 await WriteHeadersAsync(stream, request.Content.Headers, cancellationToken).ConfigureAwait(false);
-                
             }
             await stream.WriteAsync(_eol, 0, _eol.Length, cancellationToken).ConfigureAwait(false);
         }

--- a/src/HttpOverStream/HttpHeaderWriter.cs
+++ b/src/HttpOverStream/HttpHeaderWriter.cs
@@ -32,9 +32,7 @@ namespace HttpOverStream
                 var separator = header.Key == "Server" ? " " : ", ";
                 var values = string.Join(separator, header.Value);
                 var line = $"{header.Key}: {values}\n";
-                //var line = $"{header.Key}: {values}\n".Substring(0, 5) + "\n"; // TODO: REMOVE SUBSTRING
                 var payload = Encoding.ASCII.GetBytes(line);
-                //await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
                 await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
https://docker.atlassian.net/browse/DESKTOP-752

**Changes**
1. Used the MS / Go pattern of a dummy server and client connection and leaving that open to keep a namedpipe alive
2. Now we block the server creation thread until the dummy server and client are complete AND at least 1 listener.
3. Catching some specific exceptions for specific cases:
--- OperationCanceledException, thrown when cancellationToken is cancelled
--- IOException, thrown when the client disconnects early
--- EndOfStreamException when client disconnects early or you get an invalid http request
--- AggregateException when cancelling the token
4. Put the memory stream in a using block to dispose it
5. Client now sends the body on a separate thread and starts reading the response at the same time, in case the server never reads the body and responds immediately (e.g. 404 / 400 etc)


**TESTS:** 
1. Added stress test versions of all tests. 
2. Added StopAsync call to tests that create a NamedPipeListener manually

**TODO**
- Add logger