### PR TITLE
Avoid copying response body

### DIFF
--- a/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
+++ b/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -45,10 +45,10 @@
       <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -107,14 +107,14 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="pack">
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
-  <Target Name="pack">
-  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
+++ b/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndToEndTests.cs" />
+    <Compile Include="OnceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HttpOverStream.Server.Owin.Tests/OnceTests.cs
+++ b/src/HttpOverStream.Server.Owin.Tests/OnceTests.cs
@@ -19,7 +19,7 @@ namespace HttpOverStream.Server.Owin.Tests
             var once = new Once<int>(() => Interlocked.Increment(ref value));
             Parallel.For(0, 1000, _ =>
             {
-                once.Do();
+                once.EnsureDone();
             });
             Assert.AreEqual(1, value);
         }

--- a/src/HttpOverStream.Server.Owin.Tests/OnceTests.cs
+++ b/src/HttpOverStream.Server.Owin.Tests/OnceTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HttpOverStream.Server.Owin.Tests
+{
+
+    [TestClass]
+    public class OnceTests
+    {
+        [TestMethod]
+        public void TestOnceCallsOnlyOnce()
+        {
+            int value = 0;
+            var once = new Once<int>(() => Interlocked.Increment(ref value));
+            Parallel.For(0, 1000, _ =>
+            {
+                once.Do();
+            });
+            Assert.AreEqual(1, value);
+        }
+    }
+}

--- a/src/HttpOverStream.Server.Owin.Tests/packages.config
+++ b/src/HttpOverStream.Server.Owin.Tests/packages.config
@@ -4,8 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.6" targetFramework="net461" />
   <package id="Microsoft.Owin" version="4.0.1" targetFramework="net461" />
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />

--- a/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
+++ b/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
@@ -41,31 +41,40 @@ namespace HttpOverStream.Server.Owin
             {
                 using (stream)
                 {
+                    var sendHeadersCallback = new List<(Action<object>, object)>();
                     var owinContext = new OwinContext();
+                    // this is an owin extension
+                    owinContext.Set<Action<Action<object>, object>>("server.OnSendingHeaders", (callback, state) =>
+                    {
+                        sendHeadersCallback.Add((callback, state));
+                    });
                     owinContext.Set("owin.Version", "1.0");
+
                     Debug.WriteLine("Server: reading message..");
                     await PopulateRequestAsync(stream, owinContext.Request, CancellationToken.None).ConfigureAwait(false);
                     Debug.WriteLine("Server: finished reading message");
-                    using (var body = new MemoryStream())
+                    var body = new WriteInterceptStream(stream, async () =>
                     {
-                        owinContext.Response.Body = body;
-                        // execute higher level middleware
-                        Debug.WriteLine("Server: executing middleware..");
-                        await _app(owinContext.Environment).ConfigureAwait(false);
-                        Debug.WriteLine("Server: finished executing middleware..");
-                        // write the response
-                        await body.FlushAsync().ConfigureAwait(false);
-                        Debug.WriteLine("Server: flushed.");
+                        // notify we are sending headers
+                        foreach ((var callback, var state) in sendHeadersCallback)
+                        {
+                            callback(state);
+                        }
+                        // send status and headers
                         string statusCode = owinContext.Response.StatusCode.ToString();
                         Debug.WriteLine("Server: Statuscode was " + statusCode);
                         await stream.WriteResponseStatusAndHeadersAsync(owinContext.Request.Protocol, statusCode, owinContext.Response.ReasonPhrase, owinContext.Response.Headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), CancellationToken.None).ConfigureAwait(false);
                         Debug.WriteLine("Server: Wrote status and headers.");
-                        body.Position = 0;
-                        await body.CopyToAsync(stream).ConfigureAwait(false);
-                        Debug.WriteLine("Server: CopyToAsync.");
                         await stream.FlushAsync().ConfigureAwait(false);
-                        Debug.WriteLine("Server: Flush 2.");
-                    }
+
+                    });
+                    owinContext.Response.Body = body;
+                    // execute higher level middleware
+                    Debug.WriteLine("Server: executing middleware..");
+                    await _app(owinContext.Environment).ConfigureAwait(false);
+                    Debug.WriteLine("Server: finished executing middleware..");
+                    await body.FlushAsync().ConfigureAwait(false);
+                    Debug.WriteLine("Server: Flush 2.");
                 }
             }
             catch (EndOfStreamException e)
@@ -114,7 +123,7 @@ namespace HttpOverStream.Server.Owin
             long? length = null;
 
             var contentLengthValues = request.Headers.GetValues("Content-Length");
-            if (contentLengthValues!= null && contentLengthValues.Count > 0)
+            if (contentLengthValues != null && contentLengthValues.Count > 0)
             {
                 length = long.Parse(contentLengthValues[0]);
             }
@@ -152,7 +161,7 @@ namespace HttpOverStream.Server.Owin
         {
             IServiceProvider services = ServicesFactory.Create();
             var engine = services.GetService<IHostingEngine>();
-            context.ServerFactory = new ServerFactoryAdapter(new CustomListenerHostFactory(listener));            
+            context.ServerFactory = new ServerFactoryAdapter(new CustomListenerHostFactory(listener));
             return engine.Start(context);
         }
 
@@ -179,6 +188,99 @@ namespace HttpOverStream.Server.Owin
             }
         }
 
-    }
+        private class WriteInterceptStream : Stream
+        {
+            private readonly Stream _innerStream;
+            private Func<Task> _once;
 
+            public WriteInterceptStream(Stream innerStream, Func<Task> once)
+            {
+                _innerStream = innerStream;
+                _once = once;
+            }
+
+            public override void Flush()
+            {
+                var once = Interlocked.Exchange(ref _once, null);
+                if (once != null)
+                {
+                    once().Wait();
+                }
+                _innerStream.Flush();
+            }
+            public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+            public override void SetLength(long value) => _innerStream.SetLength(value);
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                var once = Interlocked.Exchange(ref _once, null);
+                if (once != null)
+                {
+                    once().Wait();
+                }
+                _innerStream.Write(buffer, offset, count);
+            }
+
+            public override bool CanRead => false;
+            public override bool CanSeek => _innerStream.CanSeek;
+            public override bool CanWrite => _innerStream.CanWrite;
+            public override long Length => _innerStream.Length;
+            public override long Position { get => _innerStream.Position; set => _innerStream.Position = value; }
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            {
+                var task = WriteAsync(buffer, offset, count);
+                var tcs = new TaskCompletionSource<int>(state);
+                task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                        tcs.TrySetException(t.Exception.InnerExceptions);
+                    else if (t.IsCanceled)
+                        tcs.TrySetCanceled();
+                    else
+                        tcs.TrySetResult(0);
+
+                    callback?.Invoke(tcs.Task);
+                }, TaskScheduler.Default);
+                return tcs.Task;
+            }
+            public override void EndWrite(IAsyncResult asyncResult)
+            {
+                ((Task<int>)asyncResult).Wait();
+            }
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                var once = Interlocked.Exchange(ref _once, null);
+                if (once == null)
+                {
+                    return _innerStream.FlushAsync(cancellationToken);
+                }
+                return once().ContinueWith(previous =>
+                {
+                    return _innerStream.FlushAsync(cancellationToken);
+                }, cancellationToken).Unwrap();
+            }
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                var once = Interlocked.Exchange(ref _once, null);
+                if (once == null)
+                {
+                    return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+                }
+                return once().ContinueWith(previous =>
+                {
+                    return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+                }, cancellationToken).Unwrap();
+            }
+            public override void WriteByte(byte value)
+            {
+                var once = Interlocked.Exchange(ref _once, null);
+                if (once != null)
+                {
+                    once().Wait();
+                }
+                _innerStream.WriteByte(value);
+            }
+        }
+    }
 }

--- a/src/HttpOverStream.Server.Owin/Once.cs
+++ b/src/HttpOverStream.Server.Owin/Once.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HttpOverStream.Server.Owin
+{
+    public class Once<T>
+    {
+        private Func<T> _todo;
+        public Once(Func<T> todo)
+        {
+            _todo = todo;
+        }
+
+        public (T, bool) Do()
+        {
+            var todo = Interlocked.Exchange(ref _todo, null);
+            if (todo == null)
+            {
+                return (default(T), false);
+            }
+            return (todo(), true);
+        }
+    }
+}

--- a/src/HttpOverStream.Server.Owin/Once.cs
+++ b/src/HttpOverStream.Server.Owin/Once.cs
@@ -9,20 +9,21 @@ namespace HttpOverStream.Server.Owin
 {
     public class Once<T>
     {
+        private T _result;
         private Func<T> _todo;
         public Once(Func<T> todo)
         {
             _todo = todo;
         }
 
-        public (T, bool) Do()
+        public T EnsureDone()
         {
             var todo = Interlocked.Exchange(ref _todo, null);
-            if (todo == null)
+            if (todo != null)
             {
-                return (default(T), false);
+                _result = todo();
             }
-            return (todo(), true);
+            return _result;
         }
     }
 }


### PR DESCRIPTION
This avoids introducing a memory stream buffering the whole response content.
This should have a positive impact on memory consumption.