### PR TITLE
Use Newtonsoft.Json version 11.0.2 consistently

### DIFF
--- a/src/HttpOverStream.NamedPipe/HttpOverStream.NamedPipe.csproj
+++ b/src/HttpOverStream.NamedPipe/HttpOverStream.NamedPipe.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We were using a different version in 2 libraries which means any client needs binding redirects

I didn't use the latest because there seems to be some requirement somewhere in OWIN that its <=12.0.0