### PR TITLE
DESKTOP-1051: Fix pending client connections breaking the dummy server boot

### DIFF
--- a/src/HttpOverStream.NamedPipe/NamedPipeDialer.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeDialer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.IO.Pipes;
 using System.Net.Http;
 using System.Threading;
@@ -11,27 +12,41 @@ namespace HttpOverStream.NamedPipe
         private readonly string _pipeName;
         private readonly string _serverName;
         private readonly PipeOptions _pipeOptions;
-        private readonly int _timeout;
+        private readonly int _timeoutMs;
 
-        public NamedPipeDialer(string pipeName) 
+        public NamedPipeDialer(string pipeName)
             : this(pipeName, ".", PipeOptions.Asynchronous, 0)
         {
         }
-        public NamedPipeDialer(string pipeName, string serverName, PipeOptions pipeOptions, int timeout)
+
+        public NamedPipeDialer(string pipeName, int timeoutMs)
+            : this(pipeName, ".", PipeOptions.Asynchronous, timeoutMs)
+        {
+        }
+
+        public NamedPipeDialer(string pipeName, string serverName, PipeOptions pipeOptions, int timeoutMs)
         {
             _pipeName = pipeName;
             _serverName = serverName;
             _pipeOptions = pipeOptions;
-            _timeout = timeout;
+            _timeoutMs = timeoutMs;
         }
 
         public async ValueTask<Stream> DialAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var pipeStream = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, _pipeOptions);
-            await pipeStream.ConnectAsync(_timeout, cancellationToken).ConfigureAwait(false);
+            await pipeStream.ConnectAsync(_timeoutMs, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.CanBeCanceled)
             {
-                var registration = cancellationToken.Register(() => pipeStream.Dispose());
+                cancellationToken.Register(() => 
+                    {
+                        try
+                        {
+                            pipeStream.Dispose();
+                        }
+                        catch (Exception) { }
+                    }
+                );
             }
             return pipeStream;
         }


### PR DESCRIPTION
This isn't a perfect implementation. Right now, we're closing all pending client connections and then starting the server. This means all clients will get an EOF or similar error if they try to connect before the server is ready, and will need to retry. In an ideal world, we would take every pending client request and pass them onto real server threads, and then connect the dummy client after all the pending client requests are dealt with. 

This might not be a big deal because often clients have a timeout / retry loop waiting for the server to come up anyway and if you try to connect before the server is ready, its reasonable to expect errors.

To reach the ideal world we'd need some way of the server identifying a dummy client connection and keeping it open. This would require a change to the protocol which may interfere with the generic named pipe solution, which is why i'm committing the basic, reliable but somewhat awkward implementation here.

Signed-off-by: Mike Parker <michael.parker@docker.com>