### PR TITLE
Allow injecting a logger

### DIFF
--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using HttpOverStream.Logging;
 
 namespace HttpOverStream.Client
 {
@@ -12,10 +13,12 @@ namespace HttpOverStream.Client
     {
         public const string UnderlyingStreamProperty = "DIAL_UNDERLYING_STREAM";
         private readonly IDial _dial;
+        private readonly ILoggerHttpOverStream _logger;
 
-        public DialMessageHandler(IDial dial)
+        public DialMessageHandler(IDial dial, ILoggerHttpOverStream logger = null)
         {
             _dial = dial;
+            _logger = logger ?? new NoopLogger();
         }
 
         private class DialResponseContent : HttpContent
@@ -66,13 +69,13 @@ namespace HttpOverStream.Client
             Stream stream = null;
             try
             {
-                Debug.WriteLine("Client: About to connect");
+                _logger.LogVerbose("Client: Trying to connect..");
                 stream = await _dial.DialAsync(request, cancellationToken).ConfigureAwait(false);
 
-                Debug.WriteLine("Client: Connected");
+                _logger.LogVerbose("Client: Connected.");
                 request.Properties.Add(UnderlyingStreamProperty, stream);
 
-                Debug.WriteLine("Client: Writing request");
+                _logger.LogVerbose("Client: Writing request");
                 await stream.WriteClientMethodAndHeadersAsync(request, cancellationToken).ConfigureAwait(false);
 
                 // as soon as headers are sent, we should begin reading the response, and send the request body concurrently
@@ -82,33 +85,33 @@ namespace HttpOverStream.Client
                     {
                         if (request.Content != null)
                         {
-                            Debug.WriteLine("Client: Writing request request.Content.CopyToAsync");
+                            _logger.LogVerbose("Client: Writing request request.Content.CopyToAsync");
                             await request.Content.CopyToAsync(stream).ConfigureAwait(false);
                         }
-                        Debug.WriteLine("Client:  stream.FlushAsync");
+                        _logger.LogVerbose("Client:  stream.FlushAsync");
                         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                        Debug.WriteLine("Client: Finished writing request");
+                        _logger.LogVerbose("Client: Finished writing request");
                     }, cancellationToken);
 
                 var responseContent = new DialResponseContent();
                 var response = new HttpResponseMessage { RequestMessage = request, Content = responseContent };
 
-                Debug.WriteLine("Client: Waiting for response");
+                _logger.LogVerbose("Client: Waiting for response");
                 string statusLine = await stream.ReadLineAsync(cancellationToken).ConfigureAwait(false);
-                Debug.WriteLine("Client: Read 1st response line");
+                _logger.LogVerbose("Client: Read 1st response line");
                 ParseStatusLine(response, statusLine);
-                Debug.WriteLine("Client: ParseStatusLine");
+                _logger.LogVerbose("Client: ParseStatusLine");
                 for (; ; )
                 {
                     var line = await stream.ReadLineAsync(cancellationToken).ConfigureAwait(false);
                     if (line.Length == 0)
                     {
-                        Debug.WriteLine("Client: Found empty line, end of response headers");
+                        _logger.LogVerbose("Client: Found empty line, end of response headers");
                         break;
                     }
                     try
                     {
-                        Debug.WriteLine("Client: Parsing line:" + line);
+                        _logger.LogVerbose("Client: Parsing line:" + line);
                         (var name, var value) = HttpParser.ParseHeaderNameValues(line);
                         if (!response.Headers.TryAddWithoutValidation(name, value))
                         {
@@ -120,13 +123,13 @@ namespace HttpOverStream.Client
                         throw new HttpRequestException("Error parsing header", ex);
                     }
                 }
-                Debug.WriteLine("Client: Finished reading response header lines");
+                _logger.LogVerbose("Client: Finished reading response header lines");
                 responseContent.SetContent(new BodyStream(stream, response.Content.Headers.ContentLength, closeOnReachEnd: true), response.Content.Headers.ContentLength);
                 return response;
             }
             catch(Exception e)
             {
-                Debug.WriteLine("Client: EXCEPTION:" + e);
+                _logger.LogError("Client: EXCEPTION:" + e);
                 stream?.Dispose();
                 throw;
             }

--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -73,7 +73,7 @@ namespace HttpOverStream.Client
                 request.Properties.Add(UnderlyingStreamProperty, stream);
 
                 Debug.WriteLine("Client: Writing request");
-                await stream.WriteMethodAndHeadersAsync(request, cancellationToken).ConfigureAwait(false);
+                await stream.WriteClientMethodAndHeadersAsync(request, cancellationToken).ConfigureAwait(false);
 
                 // as soon as headers are sent, we should begin reading the response, and send the request body concurrently
                 // This is because if the server 404s nothing will ever read the response and it'll hang waiting

--- a/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
@@ -1,14 +1,15 @@
 ﻿using HttpOverStream.Client;
 using System;
 using System.Net.Http;
+using HttpOverStream.Logging;
 
 namespace HttpOverStream.NamedPipe
 {
     public class NamedPipeHttpClientFactory
     {
-        public static HttpClient ForPipeName(string pipeName, TimeSpan? perRequestTimeout = null)
+        public static HttpClient ForPipeName(string pipeName, ILoggerHttpOverStream logger = null, TimeSpan? perRequestTimeout = null)
         {
-            var httpClient = new HttpClient(new DialMessageHandler(new NamedPipeDialer(pipeName)))
+            var httpClient = new HttpClient(new DialMessageHandler(new NamedPipeDialer(pipeName), logger))
             {
                 BaseAddress = new Uri("http://localhost")
             };

--- a/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
@@ -6,16 +6,16 @@ namespace HttpOverStream.NamedPipe
 {
     public class NamedPipeHttpClientFactory
     {
-        public static HttpClient ForPipeName(string pipeName, TimeSpan? timeout = null)
+        public static HttpClient ForPipeName(string pipeName, TimeSpan? perRequestTimeout = null)
         {
             var httpClient = new HttpClient(new DialMessageHandler(new NamedPipeDialer(pipeName)))
             {
                 BaseAddress = new Uri("http://localhost")
             };
 
-            if (timeout != null)
+            if (perRequestTimeout != null)
             {
-                httpClient.Timeout = timeout.Value;
+                httpClient.Timeout = perRequestTimeout.Value;
             }
 
             return httpClient;

--- a/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeListener.cs
@@ -6,6 +6,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using HttpOverStream.Logging;
 
 namespace HttpOverStream.NamedPipe
 {
@@ -18,18 +19,20 @@ namespace HttpOverStream.NamedPipe
         private readonly PipeTransmissionMode _pipeTransmissionMode;
         private readonly int _maxAllowedServerInstances;
         private static readonly int _numServerThreads = 5;
+        private readonly ILoggerHttpOverStream _logger;
 
-        public NamedPipeListener(string pipeName)
-            : this(pipeName, PipeOptions.Asynchronous, PipeTransmissionMode.Byte, NamedPipeServerStream.MaxAllowedServerInstances)
+        public NamedPipeListener(string pipeName, ILoggerHttpOverStream logger = null)
+            : this(pipeName, PipeOptions.Asynchronous, PipeTransmissionMode.Byte, NamedPipeServerStream.MaxAllowedServerInstances, logger)
         {
         }
 
-        public NamedPipeListener(string pipeName, PipeOptions pipeOptions, PipeTransmissionMode pipeTransmissionMode, int maxAllowedServerInstances)
+        public NamedPipeListener(string pipeName, PipeOptions pipeOptions, PipeTransmissionMode pipeTransmissionMode, int maxAllowedServerInstances, ILoggerHttpOverStream logger)
         {
             _pipeName = pipeName;
             _pipeOptions = pipeOptions;
             _pipeTransmissionMode = pipeTransmissionMode;
             _maxAllowedServerInstances = maxAllowedServerInstances;
+            _logger = logger ?? new NoopLogger();
         }
 
         public Task StartAsync(Action<Stream> onConnection, CancellationToken cancellationToken)
@@ -46,23 +49,24 @@ namespace HttpOverStream.NamedPipe
 
             // We block on creating the dummy server/client to ensure we definitely have that set up before doing anything else
             var (dummyClient, dummyServer) = ConnectDummyClientAndServer(cancellationToken);
-            tasks.Add(Task.Run(() => DisposeWhenCancelled(dummyClient, cancellationToken)));
-            tasks.Add(Task.Run(() => DisposeWhenCancelled(dummyServer, cancellationToken)));
+            tasks.Add(Task.Run(() => DisposeWhenCancelled(dummyClient, "client", cancellationToken)));
+            tasks.Add(Task.Run(() => DisposeWhenCancelled(dummyServer, "server", cancellationToken)));
 
             // This runs synchronously until we've created the first server listener to ensure we can handle at least the first client connection
-            var listenTask = CreateServerStreamAndListen(onConnection, cancellationToken);
+            var listenTask = CreateServerStreamAndListen(-1, onConnection, cancellationToken);
             tasks.Add(listenTask);
 
             // We don't technically need more than 1 thread but its faster
             for (int i = 0; i < _numServerThreads - 1; i++)
             {
-                tasks.Add(Task.Run(() => CreateServerStreamAndListen(onConnection, cancellationToken), cancellationToken));
+                var i1 = i; // Capture value immediately to prevent late closure binding
+                tasks.Add(Task.Run(() => CreateServerStreamAndListen(i1, onConnection, cancellationToken), cancellationToken));
             }
 
             return Task.WhenAll(tasks);
         }
 
-        // We dont use the cancellation token but others might
+        // We dont use the cancellation token but other implementations might
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             try
@@ -83,7 +87,8 @@ namespace HttpOverStream.NamedPipe
             }
         }
 
-        private async Task CreateServerStreamAndListen(Action<Stream> onConnection, CancellationToken cancelToken)
+        private async Task CreateServerStreamAndListen(int threadNumber, Action<Stream> onConnection,
+            CancellationToken cancelToken)
         {
             try
             {
@@ -92,39 +97,44 @@ namespace HttpOverStream.NamedPipe
                     var serverStream = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, _maxAllowedServerInstances, _pipeTransmissionMode, _pipeOptions);
                     try
                     {
+                        _logger.LogVerbose("[ thread " + threadNumber + "] Waiting for connection..");
                         await serverStream.WaitForConnectionAsync(cancelToken).ConfigureAwait(false);
-
+                        _logger.LogVerbose("[ thread " + threadNumber + "] Found connection!");
                         // MP: We deliberately don't await this because we want to kick off the work on a background thead
                         // and immediately check for the next client connecting
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                        Task.Run(() => onConnection(serverStream));
+                        Task.Run(() => onConnection(serverStream), cancelToken);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                     }
                     catch (OperationCanceledException) // Thrown when cancellationToken is cancelled
                     {
+                        _logger.LogVerbose("[ thread " + threadNumber + "] Cancelling server wait.");
                         serverStream.Dispose();
                     }
                     catch (IOException ex) // Thrown if client disconnects early
                     {
                         if (ex.Message.Contains("The pipe is being closed."))
                         {
-                            // TODO: Replace with logger
-                            Debug.WriteLine($"Could not read Named Pipe message - client disconnected before server finished reading.");
+                            _logger.LogVerbose("[ thread " + threadNumber + "] IOException: Could not read Named Pipe message - client disconnected before server finished reading.");
+                        }
+                        else
+                        {
+                            _logger.LogWarning("[ thread " + threadNumber + "] IOException, possibly because the client disconnected early:" + ex);
                         }
                         serverStream.Dispose();
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        // TODO: Maybe log
+                        _logger.LogError("[ thread " + threadNumber + "] Exception thrown during server stream wait:" + e);
                         serverStream.Dispose();
                     }
                 }
+                _logger.LogVerbose("[ thread " + threadNumber + "] Stopping thread - cancelled");
             }
             catch (Exception e)
             {
-                // TODO: Replace with logger
-                Debug.WriteLine("--- Exception creating server stream or waiting for connection: " + e);
+                _logger.LogError("[ thread " + threadNumber + "] Exception creating server stream:" + e);
             }
         }
 
@@ -146,18 +156,24 @@ namespace HttpOverStream.NamedPipe
                 }
                 catch (Exception)
                 {
-                    Debug.WriteLine("Dummy client couldn't connect, usually because a real client has a pending connection. Closing the pending connection and restarting server..");
+                    _logger.LogVerbose("[DUMMY] Dummy client couldn't connect, usually because a real client is trying to connect before the server is ready. Closing the pending connection and restarting server..");
                     serverStream.Disconnect();
                     continue;
                 }
 
+                _logger.LogVerbose("[DUMMY] Connected!");
                 return (dummyClientStream, serverStream);
             }
 
-            throw new Exception("Could not start server - dummy connection could not be made after " + MAX_DUMMYCONNECTION_RETRIES + " retries. This could be because there are too many pending connections on this named pipe. Ensure clients don't spam the server before it's ready.");
+            var errorMessage =
+                $"Could not start server - dummy connection could not be made after {MAX_DUMMYCONNECTION_RETRIES} retries. " +
+                "This could be because there are too many pending connections on this named pipe. Ensure clients don't spam the server before it's ready.";
+            _logger.LogError(errorMessage);
+            throw new Exception(errorMessage);
         }
 
-        private async Task DisposeWhenCancelled(IDisposable disposable, CancellationToken cancellationToken)
+        private async Task DisposeWhenCancelled(IDisposable disposable, string threadName,
+            CancellationToken cancellationToken)
         {
             await cancellationToken.WhenCanceled().ConfigureAwait(false);
 
@@ -167,8 +183,7 @@ namespace HttpOverStream.NamedPipe
             }
             catch (Exception e)
             {
-                // TODO: Replace with logger
-                Debug.WriteLine("--- Dummyclientstream dispose EXCEPTION " + e);
+                _logger.LogError($"Exception disposing dummy {threadName} stream: {e}");
             }
         }
     }

--- a/src/HttpOverStream.Server.AspnetCore/CustomListenerHost.cs
+++ b/src/HttpOverStream.Server.AspnetCore/CustomListenerHost.cs
@@ -49,7 +49,7 @@ namespace HttpOverStream.Server.AspnetCore
                     var body = new MemoryStream();
                     responseFeature.Body = body;
                     await application.ProcessRequestAsync(ctx).ConfigureAwait(false);
-                    await stream.WriteResponseStatusAndHeadersAsync(requestFeature.Protocol, responseFeature.StatusCode.ToString(), responseFeature.ReasonPhrase, responseFeature.Headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), CancellationToken.None).ConfigureAwait(false);                    
+                    await stream.WriteServerResponseStatusAndHeadersAsync(requestFeature.Protocol, responseFeature.StatusCode.ToString(), responseFeature.ReasonPhrase, responseFeature.Headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), _=>{}, CancellationToken.None).ConfigureAwait(false);                    
                     body.Position = 0;
                     await body.CopyToAsync(stream).ConfigureAwait(false);
                     await stream.FlushAsync().ConfigureAwait(false);

--- a/src/HttpOverStream.Server.Owin.Tests/EndToEndTests.cs
+++ b/src/HttpOverStream.Server.Owin.Tests/EndToEndTests.cs
@@ -344,12 +344,15 @@ namespace HttpOverStream.Server.Owin.Tests
 
         class TestLoggerFactory : ILoggerFactory, ILogger
         {
-            public TaskCompletionSource<Exception> ExceptionReceived { get; private set; } = new TaskCompletionSource<Exception>();
+            public TaskCompletionSource<Exception> ExceptionReceived { get; } = new TaskCompletionSource<Exception>();
             public ILogger Create(string name) => this;
             
             public bool WriteCore(TraceEventType eventType, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
             {
-                ExceptionReceived.TrySetResult(exception);
+                if (exception != null)
+                {
+                    ExceptionReceived.TrySetResult(exception);
+                }
                 return true;
             }
         }

--- a/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
+++ b/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
@@ -51,10 +51,10 @@ namespace HttpOverStream.Server.Owin
                         onSendingHeadersCallbacks.Add((callback, state));
                     });
                     owinContext.Set("owin.Version", "1.0");
-                    
-                    Log("Server: reading message..");
+
+                    _logger.WriteVerbose("Server: reading message..");
                     await PopulateRequestAsync(stream, owinContext.Request, CancellationToken.None).ConfigureAwait(false);
-                    Log("Server: finished reading message");
+                    _logger.WriteVerbose("Server: finished reading message");
                     Func<Task> sendHeadersAsync = async () =>
                     {
                         // notify we are sending headers
@@ -64,15 +64,15 @@ namespace HttpOverStream.Server.Owin
                         }
                         // send status and headers
                         string statusCode = owinContext.Response.StatusCode.ToString();
-                        Log("Server: Statuscode was " + statusCode);
-                        await stream.WriteResponseStatusAndHeadersAsync(owinContext.Request.Protocol, statusCode, owinContext.Response.ReasonPhrase, owinContext.Response.Headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), CancellationToken.None).ConfigureAwait(false);
-                        Log("Server: Wrote status and headers.");
+                        _logger.WriteVerbose("Server: Statuscode was " + statusCode);
+                        await stream.WriteServerResponseStatusAndHeadersAsync(owinContext.Request.Protocol, statusCode, owinContext.Response.ReasonPhrase, owinContext.Response.Headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), _logger.WriteVerbose, CancellationToken.None).ConfigureAwait(false);
+                        _logger.WriteVerbose("Server: Wrote status and headers.");
                         await stream.FlushAsync().ConfigureAwait(false);
                     };
                     var body = new WriteInterceptStream(stream, sendHeadersAsync);
                     owinContext.Response.Body = body;
                     // execute higher level middleware
-                    Log("Server: executing middleware..");
+                    _logger.WriteVerbose("Server: executing middleware..");
                     try
                     {
                         await _app(owinContext.Environment).ConfigureAwait(false);
@@ -81,34 +81,25 @@ namespace HttpOverStream.Server.Owin
                     {
                         await HandleMiddlewareException(e, owinContext, body);
                     }
-                    Log("Server: finished executing middleware..");
+                    _logger.WriteVerbose("Server: finished executing middleware..");
                     await body.FlushAsync().ConfigureAwait(false);
-                    Log("Server: Flush 2.");
+                    _logger.WriteVerbose("Server: Finished request. Disposing connection.");
                 }
             }
             catch (EndOfStreamException e)
             {
-                Log("Server: Error handling client stream, (Client disconnected early / invalid HTTP request)");
-                _logger?.WriteWarning("Error handling client stream, (Client disconnected early / invalid HTTP request)", e);
+                _logger.WriteWarning("Server: Error handling client stream, (Client disconnected early / invalid HTTP request)", e);
             }
             catch (Exception e)
             {
-                Log("Server: Error handling client stream " + e);
-                _logger?.WriteWarning("error handling client stream", e);
+                _logger.WriteError("Server: Error handling client stream " + e);
             }
-        }
-
-        private void Log(string msg)
-        {
-            _logger.WriteVerbose(msg);
-            Debug.WriteLine(msg);
         }
 
         private async Task HandleMiddlewareException(Exception e, OwinContext owinContext, WriteInterceptStream body)
         {
             var logMessage = "Exception trying to execute middleware: " + e;
-            _logger?.WriteError(logMessage);
-            Log(logMessage);
+            _logger.WriteError(logMessage);
 
             owinContext.Response.StatusCode = 500;
             var payload = Encoding.ASCII.GetBytes("Exception trying to execute middleware. See logs for details.");
@@ -126,6 +117,8 @@ namespace HttpOverStream.Server.Owin
             {
                 throw new FormatException($"{firstLine} is not a valid request status");
             }
+
+            _logger.WriteVerbose("Incoming request:" + firstLine);
             request.Method = parts[0];
             request.Protocol = parts[2];
             var uri = new Uri(parts[1], UriKind.RelativeOrAbsolute);
@@ -140,6 +133,7 @@ namespace HttpOverStream.Server.Owin
                 {
                     break;
                 }
+                _logger.WriteVerbose("Incoming header:" + line);
                 (var name, var values) = HttpParser.ParseHeaderNameValues(line);
                 request.Headers.Add(name, values.ToArray());
             }

--- a/src/HttpOverStream/HttpHeaderWriter.cs
+++ b/src/HttpOverStream/HttpHeaderWriter.cs
@@ -12,32 +12,34 @@ namespace HttpOverStream
     public static class HttpHeaderWriter
     {
         static byte[] _eol = Encoding.ASCII.GetBytes("\n");
-        public static async Task WriteResponseStatusAndHeadersAsync(this Stream stream, string protocol, string statusCode, string reasonPhrase, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
+        public static async Task WriteServerResponseStatusAndHeadersAsync(this Stream stream, string protocol,
+            string statusCode, string reasonPhrase, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
+            Action<string> log, CancellationToken cancellationToken)
         {
             var statusLine = $"{protocol} {statusCode} {reasonPhrase}\n";
-            var payload = Encoding.ASCII.GetBytes(statusLine);
-            Debug.WriteLine("-- Server: Trying to write statusline: " + statusLine);
-            await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
-            Debug.WriteLine("-- Server: Finished writeAsync");
-            await WriteHeadersAsync(stream, headers, cancellationToken).ConfigureAwait(false);
-            Debug.WriteLine("-- Server: Finished WriteHeadersAsync");
+            var statusLineBytes = Encoding.ASCII.GetBytes(statusLine);
+            log("Status line:" + statusLine);
+            await stream.WriteAsync(statusLineBytes, 0, statusLineBytes.Length, cancellationToken).ConfigureAwait(false);
+            await WriteHeadersAsync(stream, headers, log, cancellationToken).ConfigureAwait(false);
             await stream.WriteAsync(_eol, 0, _eol.Length, cancellationToken).ConfigureAwait(false);
-            Debug.WriteLine("-- Server: Finished writeAsync eol");
         }
 
-        private static async Task WriteHeadersAsync(Stream stream, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, CancellationToken cancellationToken)
+        private static async Task WriteHeadersAsync(Stream stream,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, Action<string> log,
+            CancellationToken cancellationToken)
         {
             foreach(var header in headers)
             {
                 var separator = header.Key == "Server" ? " " : ", ";
                 var values = string.Join(separator, header.Value);
                 var line = $"{header.Key}: {values}\n";
+                log(header.Key + " Header:" + line);
                 var payload = Encoding.ASCII.GetBytes(line);
                 await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public static async Task WriteMethodAndHeadersAsync(this Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
+        public static async Task WriteClientMethodAndHeadersAsync(this Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var firstLine = $"{request.Method.Method} {request.RequestUri.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped)} HTTP/{request.Version}\n";
             var payload = Encoding.ASCII.GetBytes(firstLine);
@@ -45,7 +47,7 @@ namespace HttpOverStream
             Debug.WriteLine("-- Client: Writing request - first line");
             await stream.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
             Debug.WriteLine("-- Client: Writing request - headers");
-            await WriteHeadersAsync(stream, request.Headers, cancellationToken).ConfigureAwait(false);
+            await WriteHeadersAsync(stream, request.Headers, _ => { }, cancellationToken).ConfigureAwait(false);
             if(request.Content != null)
             {
                 if (!request.Content.Headers.ContentLength.HasValue)
@@ -54,7 +56,7 @@ namespace HttpOverStream
                     // force populating the underlying headers collection
                     request.Content.Headers.ContentLength = request.Content.Headers.ContentLength;
                 }
-                await WriteHeadersAsync(stream, request.Content.Headers, cancellationToken).ConfigureAwait(false);
+                await WriteHeadersAsync(stream, request.Content.Headers, _ => { }, cancellationToken).ConfigureAwait(false);
             }
             await stream.WriteAsync(_eol, 0, _eol.Length, cancellationToken).ConfigureAwait(false);
         }

--- a/src/HttpOverStream/Logging/ILoggerHttpOverStream.cs
+++ b/src/HttpOverStream/Logging/ILoggerHttpOverStream.cs
@@ -1,0 +1,9 @@
+﻿namespace HttpOverStream.Logging
+{
+    public interface ILoggerHttpOverStream
+    {
+        void LogError(string message);
+        void LogWarning(string message);
+        void LogVerbose(string message);
+    }
+}

--- a/src/HttpOverStream/Logging/NoopLogger.cs
+++ b/src/HttpOverStream/Logging/NoopLogger.cs
@@ -1,0 +1,18 @@
+﻿namespace HttpOverStream.Logging
+{
+    public class NoopLogger : ILoggerHttpOverStream
+    {
+        public void LogVerbose(string message)
+        {
+
+        }
+
+        public void LogError(string message)
+        {
+        }
+
+        public void LogWarning(string message)
+        {
+        }
+    }
+}

--- a/src/HttpOverStream/Logging/NoopLogger.cs
+++ b/src/HttpOverStream/Logging/NoopLogger.cs
@@ -4,7 +4,6 @@
     {
         public void LogVerbose(string message)
         {
-
         }
 
         public void LogError(string message)


### PR DESCRIPTION
Previously we were using `Debug.WriteLine` a lot to diagnose threading issues. Moving forwards we probably want to allow the consumer control of whether to have trace level (verbose) logging, and to allow consumers to inject their own logging method for warnings and errors (or completely ignore / reject logs).

There is a bit of wrapping required as we use the Owin.ILogger in the Owin library but we can't rely on Owin in the other libraries. I created an `ILoggerHttpOverStream` interface as a simple adapter layer so clients will have to wrap their logger in a simple adapter class which implements that interface, but I don't think thats a large overhead and its unclear which logging interface to otherwise accept.

I have also added a thread ID to each server call, as this can be useful to diagnose whether there is a thread blocking or escape problem, and can help correlate logs from different threads if there are multiple parallel calls. I have not used a real .NET thread ID, just purely a simple integer.

Ideas welcome!