### PR TITLE
Allow HTTP 1.1

### DIFF
--- a/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeHttpClientFactory.cs
@@ -7,9 +7,9 @@ namespace HttpOverStream.NamedPipe
 {
     public class NamedPipeHttpClientFactory
     {
-        public static HttpClient ForPipeName(string pipeName, ILoggerHttpOverStream logger = null, TimeSpan? perRequestTimeout = null)
+        public static HttpClient ForPipeName(string pipeName, ILoggerHttpOverStream logger = null, TimeSpan? perRequestTimeout = null, Version httpVersion = null)
         {
-            var httpClient = new HttpClient(new DialMessageHandler(new NamedPipeDialer(pipeName), logger))
+            var httpClient = new HttpClient(new DialMessageHandler(new NamedPipeDialer(pipeName), logger, httpVersion))
             {
                 BaseAddress = new Uri("http://localhost")
             };


### PR DESCRIPTION
Previously responses from HTTP 1.1 servers would throw an exception. This is bad because nodejs cannot be configured to respond with HTTP 1.0, only HTTP 1.1. GoLang clients also always send HTTP 1.1


Signed-off-by: Mike Parker <michael.parker@docker.com>