### PR TITLE
Ensure outgoing requests are always tagged as HTTP 1.0

### DIFF
--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -187,7 +187,7 @@ namespace HttpOverStream.Client
 
         private void ValidateAndNormalizeRequest(HttpRequestMessage request)
         {
-            request.Version = HttpVersion.Version11;
+            request.Version = HttpVersion.Version10;
             // Add headers to define content transfer, if not present
             if (request.Headers.TransferEncodingChunked.GetValueOrDefault())
             {


### PR DESCRIPTION
Signed-off-by: Mike Parker <michael.parker@docker.com>