### PR TITLE
Add ability to insert delegating handlers into HttpClient

### DIFF
--- a/src/HttpOverStream.Client/DialMessageHandler.cs
+++ b/src/HttpOverStream.Client/DialMessageHandler.cs
@@ -102,7 +102,7 @@ namespace HttpOverStream.Client
                         await request.Content.CopyToAsync(stream).ConfigureAwait(false);
                     }
 
-                    _logger.LogVerbose("HttpOS Client:  stream.FlushAsync");
+                    _logger.LogVerbose("HttpOS Client: stream.FlushAsync");
                     await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
                     _logger.LogVerbose("HttpOS Client: Finished writing request");
                 }, cancellationToken);

--- a/src/HttpOverStream.NamedPipe/NamedPipeHttpClientBuilder.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeHttpClientBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using HttpOverStream.Logging;
+
+namespace HttpOverStream.NamedPipe
+{
+    public class NamedPipeHttpClientBuilder
+    {
+        private string _pipeName;
+        private ILoggerHttpOverStream _logger;
+        private DelegatingHandler _outerHandler;
+        private TimeSpan? _perRequestTimeout;
+        private Version _httpVersion;
+
+        public NamedPipeHttpClientBuilder(string pipeName)
+        {
+            _pipeName = pipeName;
+        }
+
+        public NamedPipeHttpClientBuilder WithLogger(ILoggerHttpOverStream logger)
+        {
+            _logger = logger;
+            return this;
+        }
+
+        public NamedPipeHttpClientBuilder WithDelegatingHandler(DelegatingHandler outerHandler)
+        {
+            _outerHandler = outerHandler;
+            return this;
+        }
+
+        public NamedPipeHttpClientBuilder WithPerRequestTimeout(TimeSpan perRequestTimeout)
+        {
+            _perRequestTimeout = perRequestTimeout;
+            return this;
+        }
+
+        public NamedPipeHttpClientBuilder WithHttpVersion(Version httpVersion)
+        {
+            _httpVersion = httpVersion;
+            return this;
+        }
+
+        public HttpClient Build()
+        {
+            return NamedPipeHttpClientFactory.ForPipeName(_pipeName, _logger, _perRequestTimeout, _httpVersion, _outerHandler);
+        }
+    }
+}

--- a/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
+++ b/src/HttpOverStream.Server.Owin.Tests/HttpOverStream.Server.Owin.Tests.csproj
@@ -80,6 +80,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestLoggingHandler.cs" />
     <Compile Include="EndToEndTests.cs" />
     <Compile Include="OnceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/HttpOverStream.Server.Owin.Tests/TestLoggingHandler.cs
+++ b/src/HttpOverStream.Server.Owin.Tests/TestLoggingHandler.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HttpOverStream.Server.Owin.Tests
+{
+    public class TestLoggingHandler : DelegatingHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var correlationId = Guid.NewGuid();
+            LogRequest(request, correlationId);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await base.SendAsync(request, cancellationToken);
+            stopwatch.Stop();
+            LogResponse(request, response, stopwatch.Elapsed, correlationId);
+            return response;
+        }
+
+        private void LogRequest(HttpRequestMessage request, Guid correlationId)
+        {
+            if (request == null)
+            {
+                Console.WriteLine("Null request");
+                return;
+            }
+
+            Console.WriteLine($"[{correlationId}] {request.Method?.Method} {request.RequestUri}");
+        }
+
+        private void LogResponse(HttpRequestMessage request, HttpResponseMessage response, TimeSpan stopwatchElapsed, Guid correlationId)
+        {
+            Console.WriteLine($"[{correlationId}] {request?.Method?.Method} {request?.RequestUri} -> {(int)response.StatusCode} {response.StatusCode} took {(int)stopwatchElapsed.TotalMilliseconds}ms");
+        }
+    }
+}


### PR DESCRIPTION
Also make a Builder pattern for the HttpClient (as theres a lot of optional parameters now). Add a test logging handler and check it works.

This allows the caller to insert a request / response logger to output timings etc.

Signed-off-by: Mike Parker <michael.parker@docker.com>