### PR TITLE
[DESKTOP-1894]  Fix passing env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
               NugetAPIKey = credentials('nuget-api-key')
             }
             steps {
-                bat 'docker run --rm -v %cd%:C:/work -w C:/work/src mcr.microsoft.com/dotnet/framework/sdk:4.8-20190910-windowsservercore-ltsc2019 -e NugetAPIKey powershell -File build.ps1 -Target Nuget-push'
+                bat 'docker run --rm -v %cd%:C:/work -w C:/work/src -e NugetAPIKey mcr.microsoft.com/dotnet/framework/sdk:4.8-20190910-windowsservercore-ltsc2019 powershell -File build.ps1 -Target Nuget-push'
             }
         }
     }


### PR DESCRIPTION
Fix #24, pass the env before the image name.
