### PR TITLE
[DESKTOP-1894] Use Jenkins variable TAG_NAME

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
               NugetAPIKey = credentials('nuget-api-key')
             }
             steps {
-                bat 'docker run --rm -v %cd%:C:/work -w C:/work/src -e NugetAPIKey mcr.microsoft.com/dotnet/framework/sdk:4.8-20190910-windowsservercore-ltsc2019 powershell -File build.ps1 -Target Nuget-push'
+                bat 'docker run --rm -v %cd%:C:/work -w C:/work/src -e NugetAPIKey -e TAG_NAME mcr.microsoft.com/dotnet/framework/sdk:4.8-20190910-windowsservercore-ltsc2019 powershell -File build.ps1 -Target Nuget-push'
             }
         }
     }

--- a/src/build.cake
+++ b/src/build.cake
@@ -41,8 +41,8 @@ Task("Nuget-pack")
   .IsDependentOn("Nuget-Restore")
   .Does(()=>{
     var version = "0.1.0";
-    if(BuildSystem.AppVeyor.Environment.Repository.Tag.IsTag){
-      version = BuildSystem.AppVeyor.Environment.Repository.Tag.Name;
+    if(HasEnvironmentVariable("TAG_NAME")){
+      version = EnvironmentVariable("TAG_NAME");
     }
     var settings = new DotNetCorePackSettings
      {
@@ -58,7 +58,7 @@ Task("Nuget-pack")
 Task("Nuget-push")
 .IsDependentOn("Nuget-pack")
 .Does(()=>{
-  if(!BuildSystem.AppVeyor.Environment.Repository.Tag.IsTag){
+  if(!HasEnvironmentVariable("TAG_NAME")){
     return;
   }
    // Get the paths to the packages.


### PR DESCRIPTION
This PR changes the AppVeyor specific checks to Jenkins. Jenkins sets the environment variable `TAG_NAME` if it's a tagged build.
