### PR TITLE
Add user identity in Owin context

### DIFF
--- a/src/HttpOverStream.NamedPipe/NamedPipeDialer.cs
+++ b/src/HttpOverStream.NamedPipe/NamedPipeDialer.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Http;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,7 @@ namespace HttpOverStream.NamedPipe
         private readonly string _serverName;
         private readonly PipeOptions _pipeOptions;
         private readonly int _timeoutMs;
+        private readonly TokenImpersonationLevel _impersonationLevel;
 
         public NamedPipeDialer(string pipeName)
             : this(pipeName, ".", PipeOptions.Asynchronous, 0)
@@ -24,17 +26,18 @@ namespace HttpOverStream.NamedPipe
         {
         }
 
-        public NamedPipeDialer(string pipeName, string serverName, PipeOptions pipeOptions, int timeoutMs)
+        public NamedPipeDialer(string pipeName, string serverName, PipeOptions pipeOptions, int timeoutMs, TokenImpersonationLevel impersonationLevel = TokenImpersonationLevel.Identification)
         {
             _pipeName = pipeName;
             _serverName = serverName;
             _pipeOptions = pipeOptions;
             _timeoutMs = timeoutMs;
+            _impersonationLevel = impersonationLevel;
         }
 
         public async ValueTask<Stream> DialAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var pipeStream = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, _pipeOptions);
+            var pipeStream = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, _pipeOptions, _impersonationLevel);
             await pipeStream.ConnectAsync(_timeoutMs, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.CanBeCanceled)
             {

--- a/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
+++ b/src/HttpOverStream.Server.Owin/CustomListenerHost.cs
@@ -53,6 +53,12 @@ namespace HttpOverStream.Server.Owin
 
                     _logger.WriteVerbose("Server: reading message..");
                     await PopulateRequestAsync(stream, owinContext.Request, CancellationToken.None).ConfigureAwait(false);
+
+                    // some transports (shuch as Named Pipes) may require the server to read some data before being able to get the
+                    // client identity. So we get the client identity after reading the request headers
+                    var transportIdentity = _listener.GetTransportIdentity(stream);
+                    owinContext.Request.User = transportIdentity;
+
                     _logger.WriteVerbose("Server: finished reading message");
                     Func<Task> sendHeadersAsync = async () =>
                     {

--- a/src/HttpOverStream/IListen.cs
+++ b/src/HttpOverStream/IListen.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,5 +10,6 @@ namespace HttpOverStream
     {
         Task StartAsync(Action<Stream> onConnection, CancellationToken cancellationToken);
         Task StopAsync(CancellationToken cancellationToken);
+        IPrincipal GetTransportIdentity(Stream connection);
     }
 }


### PR DESCRIPTION
This add the user identity of the client in the OWin context, to be able to expose this to API controllers.